### PR TITLE
fix hyperdrive-archive-swarm module path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var createSwarm = require('../hyperdrive-archive-swarm')
+var createSwarm = require('hyperdrive-archive-swarm')
 var createStream = require('hypercore-create-stream')
 
 module.exports = function swarmStream (key, opts) {


### PR DESCRIPTION
Since there's already a `hyperdrive-archive-swarm` dependency in `package.json`, maybe this is a typo?